### PR TITLE
Rewriting gauge to not have side effects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "5"
+  - "4"
+  - iojs
+  - "0.12"
+  - "0.10"
+  - "0.8"
+before_install:
+  - "npm config set spin false"
+  - "npm install -g npm"
+sudo: false
+script: "npm test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+### v2.0.0
+
+This is a major rewrite of the internals.  Externally there are fewer
+changes:
+
+* On node>0.8 gauge object now prints updates at a fixed rate.  This means
+  that when you call `show` it may wate up to `updateInterval` ms before it
+  actually prints an update.  You override this behavior with the
+  `fixedFramerate` option.
+* The gauge object now keeps the cursor hidden as long as it's enabled and
+  shown.
+* The constructor's arguments have changed, now it takes a mandatory output
+  stream and an optional options object.  The stream no longer needs to be
+  an `ansi`ified stream, although it can be if you want (but we won't make
+  use of its special features).
+* Previously the gauge was disabled by default if `process.stdout` wasn't a
+  tty.  Now it always defaults to enabled.  If you want the previous
+  behavior set the `enabled` option to `process.stdout.isTTY`.
+* The constructor's options have changed– see the docs for details.
+* Themes are entirely different.  If you were using a custom theme, or
+  referring to one directly (eg via `Gauge.unicode` or `Gauge.ascii`) then
+  you'll need to change your code.  You can get the equivalent of the latter
+  with:
+  ```
+  var themes = require('gauge/themes')
+  var unicodeTheme = themes(true, true) // returns the color unicode theme for your platform
+  ```
+  The default themes no longer use any ambiguous width characters, so even
+  if you choose to display those as wide your progress bar should still
+  display correctly.
+* Templates are entirely different and if you were using a custom one, you
+  should consult the documentation to learn how to recreate it.  If you were
+  using the default, be aware that it has changed and the result looks quite
+  a bit different.

--- a/README.md
+++ b/README.md
@@ -18,143 +18,116 @@ gauge.hide()
 ![](example.png)
 
 
-### `var gauge = new Gauge([options], [ansiStream])`
+### CHANGES FROM 1.x
 
-* **options** – *(optional)* An option object. (See [below] for details.)
-* **ansiStream** – *(optional)* A stream that's been blessed by the [ansi]
-  module to include various commands for controlling the cursor in a terminal.
+Gauge 2.x is breaking release, please see the [changelog] for details on
+what's changed if you were previously a user of this module.
 
-[ansi]: https://www.npmjs.com/package/ansi
-[below]: #theme-objects
+[changelog]: CHANGELOG.md
+
+### THE GAUGE CLASS
+
+This is the typical interface to the module– it provides a pretty
+fire-and-forget interface to displaying your status information.
+
+```
+var Gauge = require("gauge")
+
+var gauge = new Gauge(stream, [options])
+```
+
+* **stream** – A stream that progress bar updates are to be written to. Gauge honors
+  backpressure and will pause most writing if it is indicated.
+* **options** – *(optional)* An option object.
 
 Constructs a new gauge. Gauges are drawn on a single line, and are not drawn
 if the current terminal isn't a tty.
 
-If you resize your terminal in a way that can be detected then the gauge
-will be drawn at the new size. As a general rule, growing your terminal will
-be clean, but shrinking your terminal will result in cruft as we don't have
-enough information to know where what we wrote previously is now located.
+If **stream** is a terminal or if you pass in **tty** to **options** then we
+will detect terminal resizes and redraw to fit.  We do this by watching for
+`resize` events on the tty.  (To work around a bug in verisons of Node prior
+to 2.5.0, we watch for them on stdout if the tty is stderr.) Resizes to
+larger window sizes will be clean, but shrinking the window will always
+result in some cruft.
 
 The **options** object can have the following properties, all of which are
 optional:
 
-* maxUpdateFrequency: defaults to 50 msec, the gauge will not be drawn more
-  than once in this period of time. This applies to `show` and `pulse`
-  calls, but if you `hide` and then `show` the gauge it will draw it
-  regardless of time since last draw.
-* theme: defaults to Gauge.unicode` if the terminal supports
-  unicode according to [has-unicode], otherwise it defaults to `Gauge.ascii`.
-  Details on the [theme object](#theme-objects) are documented elsewhere.
-* template: see [documentation elsewhere](#template-objects) for
-  defaults and details.
+* **updateInterval**: How often gauge updates should be drawn, in miliseconds.
+* **fixedFramerate**: Defaults to false on node 0.8, true on everything
+  else.  When this is true a timer is created to trigger once every
+  `updateInterval` ms, when false, updates are printed as soon as they come
+  in but updates more often than `updateInterval` are ignored.  The reason
+  0.8 doesn't have this set to true is that it can't `unref` its timer and
+  so it would stop your program from exiting– if you want to use this
+  feature with 0.8 just make sure you call `gauge.disable()` before you
+  expect your program to exit.
+* **theme**: The theme to use as output.  Defaults to something usable on
+  your combination of OS, color and unicode support.  In practice this means
+  that Windows always gets ASCII by default, Mac almost always gets unicode,
+  and everyone almost always gets color.  Unicode is detected with
+  [has-unicode] and color is detected with [has-color].  Theme selection is
+  done by the internal [themes] module, which you can use directly.
+* **template**: Describes what you want your gauge to look like.  The
+  default is what npm uses.  Detailed [documentation] is later in this
+  document.
+* **hideCursor**: Defaults to true.  If true, then the cursor will be hidden
+  while the gauge is displayed.
+* **tty**: The tty that you're ultimately writing to.  Defaults to the same
+  as **stream**.  This is used for detecting the width of the terminal and
+  resizes. The width used is `tty.columns - 1`. If no tty is available then
+  a width of `79` is assumed.
+* **enabled**: Defaults to true.  If true the gauge starts enabled.  If
+  disabled then all update commands are ignored and no gauge will be printed
+  until you call `.enable()`.
+* **Plumbing**: The class to use to actually generate the gauge for
+  printing.  This defaults to `require('gauge/plumbing')` and ordinarly you
+  shouldn't need to override this.
 
 [has-unicode]: https://www.npmjs.com/package/has-unicode
+[has-color]: https://www.npmjs.com/package/has-color
+[themes]: #themes
+[documentation]: #templates
 
-If **ansiStream** isn't passed in, then one will be constructed from stderr
-with `ansi(process.stderr)`.
+#### `gauge.show(section | status, [completed])`
 
-### `gauge.show([name, [completed]])`
+The first argument is either the section, the name of the current thing
+contributing to progress, or an object with keys like **section**,
+**subsection** & **completed** (or any others you have types for in a custom
+template).  If you don't want to update or set any of these you can pass
+`null` and it will be ignored.
 
-* **name** – *(optional)* The name of the current thing contributing to progress. Defaults to the last value used, or "".
-* **completed** – *(optional)* The portion completed as a value between 0 and 1. Defaults to the last value used, or 0.
+The second argument is the percent completed as a value between 0 and 1.
+Without it, completion is just not updated. You'll also note that completion
+can be passed in as part of a status object as the first argument. If both
+it and the completed argument are passed in, the completed argument wins.
 
-If `process.stdout.isTTY` is false then this does nothing. If completed is 0
-and `gauge.pulse` has never been called, then similarly nothing will be printed.
-
-If `maxUpdateFrequency` msec haven't passed since the last call to `show` or
-`pulse` then similarly, nothing will be printed.  (Actually, the update is
-deferred until `maxUpdateFrequency` msec have passed and if nothing else has
-happened, the gauge update will happen.)
-
-### `gauge.hide()`
+#### `gauge.hide()`
 
 Removes the gauge from the terminal.
 
-### `gauge.pulse([name])`
+#### `gauge.pulse([subsection])`
 
-* **name** – *(optional)* The specific thing that triggered this pulse
+* **subsection** – *(optional)* The specific thing that triggered this pulse
 
-Spins the spinner in the gauge to show output. If **name** is included then
-it will be combined with the last name passed to `gauge.show` using the
-subsection property of the theme (typically a right facing arrow).
+Spins the spinner in the gauge to show output.  If **subsection** is
+included then it will be combined with the last name passed to `gauge.show`.
 
-### `gauge.disable()`
+#### `gauge.disable()`
 
 Hides the gauge and ignores further calls to `show` or `pulse`.
 
-### `gauge.enable()`
+#### `gauge.enable()`
 
 Shows the gauge and resumes updating when `show` or `pulse` is called.
 
-### `gauge.setTheme(theme)`
+#### `gauge.setTheme(theme)`
 
 Change the active theme, will be displayed with the next show or pulse
 
-### `gauge.setTemplate(template)`
+#### `gauge.setTemplate(template)`
 
 Change the active template, will be displayed with the next show or pulse
-
-### Theme Objects
-
-There are two theme objects available as a part of the module, `Gauge.unicode` and `Gauge.ascii`.
-Theme objects have the follow properties:
-
-| Property   | Unicode | ASCII |
-| ---------- | ------- | ----- |
-| startgroup | ╢       | \|    |
-| endgroup   | ╟       | \|    |
-| complete   | █       | #     |
-| incomplete | ░       | -     |
-| spinner    | ▀▐▄▌    | -\\\|/ |
-| subsection | →       | ->    |
-
-*startgroup*, *endgroup* and *subsection* can be as many characters as you want.
-
-*complete* and *incomplete* should be a single character width each.
-
-*spinner* is a list of characters to use in turn when displaying an activity
-spinner.  The Gauge will spin as many characters as you give here.
-
-### Template Objects
-
-A template is an array of objects and strings that, after being evaluated,
-will be turned into the gauge line.  The default template is:
-
-```javascript
-[
-    {type: "name", separated: true, maxLength: 25, minLength: 25, align: "left"},
-    {type: "spinner", separated: true},
-    {type: "startgroup"},
-    {type: "completionbar"},
-    {type: "endgroup"}
-]
-```
-
-The various template elements can either be **plain strings**, in which case they will
-be be included verbatum in the output.
-
-If the template element is an object, it can have the following keys:
-
-* *type* can be:
-  * `name` – The most recent name passed to `show`; if this is in response to a
-    `pulse` then the name passed to `pulse` will be appended along with the
-    subsection property from the theme.
-  * `spinner` – If you've ever called `pulse` this will be one of the characters
-    from the spinner property of the theme.
-  * `startgroup` – The `startgroup` property from the theme.
-  * `completionbar` – This progress bar itself
-  * `endgroup` – The `endgroup` property from the theme.
-* *separated* – If true, the element will be separated with spaces from things on
-  either side (and margins count as space, so it won't be indented), but only
-  if its included.
-* *maxLength* – The maximum length for this element. If its value is longer it
-  will be truncated.
-* *minLength* – The minimum length for this element. If its value is shorter it
-  will be padded according to the *align* value.
-* *align* – (Default: left) Possible values "left", "right" and "center". Works
-  as you'd expect from word processors.
-* *length* – Provides a single value for both *minLength* and *maxLength*. If both
-  *length* and *minLength or *maxLength* are specifed then the latter take precedence.
 
 ### Tracking Completion
 
@@ -164,3 +137,154 @@ event can be wired up to the `show` method to get a more traditional
 progress bar interface.
 
 [are-we-there-yet]: https://www.npmjs.com/package/are-we-there-yet
+
+### THEMES
+
+```
+var theme = require('gauge/themes')
+
+// fetch the default color unicode theme for this platform
+var ourTheme = theme({hasUnicode: true, hasColor: true})
+
+// fetch the default non-color unicode theme for osx
+var ourTheme = theme({hasUnicode: true, hasColor: false, platform: 'darwin'})
+
+// create a new theme based on the color ascii theme for this platform
+// that brackets the progress bar with arrows
+var ourTheme = theme.newTheme(theme(hasUnicode: false, hasColor: true}), {
+  preProgressbar: '→',
+  postProgressbar: '←'
+})
+```
+
+#### theme(opts)
+
+Fetches a theme object based on platform settings.
+
+Options is an object with the following properties:
+
+* **hasUnicode** - If true, fetch a unicode theme.
+* **hasColor** - If true, fetch a color theme.
+* **platform** (optional) - Defaults to `process.platform`. The platform code of the theme we want.
+
+#### theme.newTheme([parent,] newTheme)
+
+Create a new theme object based on `parent`.  If no `parent` is provided
+then a minimal parent that defines functions for rendering the activity
+indicator (spinner) and progress bar will be defined.
+
+newTheme should be a bare object– we'll start by discussing the properties
+defined by the default themes:
+
+* **preProgressbar** - displayed prior to the progress bar, if the progress
+  bar is displayed.
+* **postProgressbar** - displayed after the progress bar, if the progress bar
+  is displayed.
+* **progressBarTheme** - The subtheme passed through to the progress bar
+  renderer, it's an object with `complete` and `remaining` properties
+  that are the strings you want repeated for those sections of the progress
+  bar.
+* **activityIndicatorTheme** - The theme for the activity indicator (spinner),
+  this can either be a string, in which each character is a different step, or
+  an array of strings.
+* **preSubsection** - Displayed as a separator between the `section` and
+  `subsection` when the latter is printed.
+
+More generally, themes can have any value that would be a valid value when rendering
+templates. The properties in the theme are used when their name matches a type in
+the template. Their values can be:
+
+* **strings & numbers** - They'll be included as is
+* **function (values, theme, width)** - Should return what you want in your output.
+  *values* is an object with values provided via `gauge.show`,
+  *theme* is the theme specific to this item (see below) or this theme object,
+  and *width* is the number of characters wide your result should be.
+
+There are a couple of special prefixes:
+
+* **pre** - Is shown prior to the property, if its displayed.
+* **post** - Is shown after the property, if its displayed.
+
+And one special suffix:
+
+* **Theme** - Its value is passed to a function-type item as the theme.
+
+### TEMPLATES
+
+A template is an array of objects and strings that, after being evaluated,
+will be turned into the gauge line.  The default template is:
+
+```javascript
+[
+    {type: 'progressbar', length: 20},
+    {type: 'activityIndicator', kerning: 1, length: 1},
+    {type: 'section', kerning: 1},
+    {type: 'subsection', kerning: 1}
+]
+```
+
+The various template elements can either be **plain strings**, in which case they will
+be be included verbatum in the output, or objects with the following properties:
+
+* *type* can be any of the following plus any keys you pass into `gauge.show` plus
+  any keys you have on a custom theme.
+  * `section` – What big thing you're working on now.
+  * `subsection` – What component of that thing is currently working.
+  * `activityIndicator` – Shows a spinner using the `activityIndicatorTheme`
+    from your active theme.
+  * `progressbar` – A progress bar representing your current `completed`
+    using the `progressbarTheme` from your active theme.
+* *kerning* – Number of spaces that must be between this item and other
+  items, if this item is displayed at all.
+* *maxLength* – The maximum length for this element. If its value is longer it
+  will be truncated.
+* *minLength* – The minimum length for this element. If its value is shorter it
+  will be padded according to the *align* value.
+* *align* – (Default: left) Possible values "left", "right" and "center". Works
+  as you'd expect from word processors.
+* *length* – Provides a single value for both *minLength* and *maxLength*. If both
+  *length* and *minLength or *maxLength* are specifed then the latter take precedence.
+* *value* – A literal value to use for this template item.
+
+### PLUMBING
+
+This is the super simple, assume nothing, do no magic internals used by gauge to
+implement its ordinary interface.
+
+```
+var Plumbing = require('gauge/plumbing')
+var gauge = new Plumbing(theme, template, width)
+```
+
+* **theme**: The theme to use.
+* **template**: The template to use.
+* **width**: How wide your gauge should be
+
+#### `gauge.setTheme(theme)`
+
+Change the active theme.
+
+#### `gauge.setTemplate(template)`
+
+Change the active template.
+
+#### `gauge.setWidth(width)`
+
+Change the width to render at.
+
+#### `gauge.hide()`
+
+Return the string necessary to hide the progress bar
+
+#### `gauge.hideCursor()`
+
+Return a string to hide the cursor.
+
+#### `gauge.showCursor()`
+
+Return a string to show the cursor.
+
+#### `gauge.show(status)`
+
+Using `status` for values, render the provided template with the theme and return
+a string that is suitable for printing to update the gauge.

--- a/console-strings.js
+++ b/console-strings.js
@@ -1,0 +1,115 @@
+'use strict'
+
+// These tables borrowed from `ansi`
+
+var prefix = '\x1b['
+
+exports.up = function up (num) {
+  return prefix + (num || '') + 'A'
+}
+
+exports.down = function down (num) {
+  return prefix + (num || '') + 'B'
+}
+
+exports.forward = function forward (num) {
+  return prefix + (num || '') + 'C'
+}
+
+exports.back = function back (num) {
+  return prefix + (num || '') + 'D'
+}
+
+exports.nextLine = function nextLine (num) {
+  return prefix + (num || '') + 'E'
+}
+
+exports.previousLine = function previousLine (num) {
+  return prefix + (num || '') + 'F'
+}
+
+exports.horizontalAbsolute = function horizontalAbsolute (num) {
+  if (num == null) throw new Error('horizontalAboslute requires a column to position to')
+  return prefix + num + 'G'
+}
+
+exports.eraseData = function eraseData () {
+  return prefix + 'J'
+}
+
+exports.eraseLine = function eraseLine () {
+  return prefix + 'K'
+}
+
+exports.goto = function (x, y) {
+  return prefix + y + ';' + x + 'H'
+}
+
+exports.hideCursor = function hideCursor () {
+  return prefix + '?25l'
+}
+
+exports.showCursor = function showCursor () {
+  return prefix + '?25h'
+}
+
+var colors = {
+  reset: 0,
+// styles
+  bold: 1,
+  italic: 3,
+  underline: 4,
+  inverse: 7,
+// resets
+  stopBold: 22,
+  stopItalic: 23,
+  stopUnderline: 24,
+  stopInverse: 27,
+// colors
+  white: 37,
+  black: 30,
+  blue: 34,
+  cyan: 36,
+  green: 32,
+  magenta: 35,
+  red: 31,
+  yellow: 33,
+  bgWhite: 47,
+  bgBlack: 40,
+  bgBlue: 44,
+  bgCyan: 46,
+  bgGreen: 42,
+  bgMagenta: 45,
+  bgRed: 41,
+  bgYellow: 43,
+
+  grey: 90,
+  brightBlack: 90,
+  brightRed: 91,
+  brightGreen: 92,
+  brightYellow: 93,
+  brightBlue: 94,
+  brightMagenta: 95,
+  brightCyan: 96,
+  brightWhite: 97,
+
+  bgGrey: 100,
+  bgBrightBlack: 100,
+  bgBrightRed: 101,
+  bgBrightGreen: 102,
+  bgBrightYellow: 103,
+  bgBrightBlue: 104,
+  bgBrightMagenta: 105,
+  bgBrightCyan: 106,
+  bgBrightWhite: 107
+}
+
+exports.color = function color () {
+  var colorWith = Array.prototype.slice.call(arguments)
+  return prefix + colorWith.map(colorNameToCode).join(';') + 'm'
+}
+
+function colorNameToCode (color) {
+  if (colors[color] != null) return colors[color]
+  throw new Error('Unknown color or style name: ' + color)
+}

--- a/error.js
+++ b/error.js
@@ -1,0 +1,24 @@
+'use strict'
+var util = require('util')
+
+var User = exports.User = function User (msg) {
+  var err = new Error(msg)
+  Error.captureStackTrace(err, User)
+  err.code = 'EGAUGE'
+  return err
+}
+
+exports.MissingTemplateValue = function MissingTemplateValue (item, values) {
+  var err = new User(util.format('Missing template value "%s"', item.type))
+  Error.captureStackTrace(err, MissingTemplateValue)
+  err.template = item
+  err.values = values
+  return err
+}
+
+exports.Internal = function Internal (msg) {
+  var err = new Error(msg)
+  Error.captureStackTrace(err, Internal)
+  err.code = 'EGAUGEINTERNAL'
+  return err
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,160 @@
+'use strict'
+var validate = require('aproba')
+var Plumbing = require('./plumbing.js')
+var hasUnicode = require('has-unicode')
+var hasColor = require('has-color')
+var onExit = require('signal-exit')
+var themes = require('./themes')
+
+module.exports = Gauge
+
+function callWith (obj, method) {
+  return function () {
+    return method.call(obj)
+  }
+}
+
+function Gauge (writeTo, options) {
+  if (!options) options = {}
+  validate('OO', [writeTo, options])
+
+  this.status = {
+    spun: 0
+  }
+  this._showing = false
+  this._onScreen = false
+  this._hideCursor = options.hideCursor == null ? true : options.hideCursor
+  this._needsRedraw = false
+  this.fixedFramerate = options.fixedFramerate == null
+    ? !(/^v0\.8\./.test(process.version))
+    : options.fixedFramerate
+  this._lastUpdateAt = null
+  this.updateInterval = options.updateInterval == null ? 50 : options.updateInterval
+  this._paused = false
+  this.tty = options.tty ||
+    (writeTo === process.stderr && process.stdout.isTTY && process.stdout) ||
+    (writeTo.isTTY && writeTo)
+
+  var theme = options.theme || themes({hasUnicode: hasUnicode(), hasColor: hasColor})
+  var template = options.template || [
+    {type: 'progressbar', length: 20},
+    {type: 'activityIndicator', kerning: 1, length: 1},
+    {type: 'section', kerning: 1},
+    {type: 'subsection', kerning: 1}
+  ]
+  var PlumbingClass = options.Plumbing || Plumbing
+  this._gauge = new PlumbingClass(theme, template, ((this.tty && this.tty.columns) || 80) - 1)
+  this._writeTo = writeTo
+
+  this._$$doRedraw = callWith(this, this._doRedraw)
+  this._$$handleSizeChange = callWith(this, this._handleSizeChange)
+
+  onExit(callWith(this, this.disable))
+
+  if (options.enabled || options.enabled == null) {
+    this.enable()
+  } else {
+    this.disable()
+  }
+}
+Gauge.prototype = {}
+
+Gauge.prototype.enable = function () {
+  this.disabled = false
+  if (this.tty) this._enableEvents()
+  if (this._showing) this.show()
+}
+
+Gauge.prototype.disable = function () {
+  if (this._showing) {
+    this._lastUpdateAt = null
+    this._showing = false
+    this._doRedraw()
+    this._showing = true
+  }
+  this.disabled = true
+  if (this.tty) this._disableEvents()
+}
+
+Gauge.prototype._enableEvents = function () {
+  this.tty.on('resize', this._$$handleSizeChange)
+  if (this.fixedFramerate) {
+    this.redrawTracker = setInterval(this._$$doRedraw, this.updateInterval)
+    if (this.redrawTracker.unref) this.redrawTracker.unref()
+  }
+}
+
+Gauge.prototype._disableEvents = function () {
+  this.tty.removeListener('resize', this._$$handleSizeChange)
+  if (this.fixedFramerate) clearInterval(this.redrawTracker)
+}
+
+Gauge.prototype.hide = function () {
+  if (this.disabled) return
+  if (!this._showing) return
+  this._showing = false
+  this._doRedraw()
+}
+
+Gauge.prototype.show = function (section, completed) {
+  if (this.disabled) return
+  this._showing = true
+  if (typeof section === 'string') {
+    this.status.section = section
+  } else if (typeof section === 'object') {
+    var sectionKeys = Object.keys(section)
+    for (var ii = 0; ii < sectionKeys.length; ++ii) {
+      var key = sectionKeys[ii]
+      this.status[key] = section[key]
+    }
+  }
+  if (completed != null) this.status.completed = completed
+  this._needsRedraw = true
+  if (!this.fixedFramerate) this._doRedraw()
+}
+
+Gauge.prototype.pulse = function (subsection) {
+  if (this.disabled) return
+  if (!this._showing) return
+  this.status.subsection = subsection
+  this.status.spun ++
+  this._needsRedraw = true
+  if (!this.fixedFramerate) this._doRedraw()
+}
+
+Gauge.prototype._handleSizeChange = function () {
+  this._gauge.setWidth(this.tty.columns - 1)
+  this._needsRedraw = true
+}
+
+Gauge.prototype._doRedraw = function () {
+  if (this.disabled || this._paused) return
+  if (!this.fixedFramerate) {
+    var now = Date.now()
+    if (this._lastUpdateAt && now - this._lastUpdateAt < this.updateInterval) return
+    this._lastUpdateAt = now
+  }
+  if (!this._showing && this._onScreen) {
+    this._onScreen = false
+    var result = this._gauge.hide()
+    if (this._hideCursor) {
+      result += this._gauge.showCursor()
+    }
+    return this._writeTo.write(result)
+  }
+  if (this._showing && !this._onScreen) {
+    this._onScreen = true
+    this._needsRedraw = true
+    if (this._hideCursor) {
+      this._writeTo.write(this._gauge.hideCursor())
+    }
+  }
+  if (!this._needsRedraw) return
+  if (!this._writeTo.write(this._gauge.show(this.status))) {
+    this._paused = true
+    this._writeTo.on('drain', callWith(this, function () {
+      this._paused = false
+      this._doRedraw()
+    }))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "gauge",
   "version": "1.2.7",
   "description": "A terminal based horizontal guage",
-  "main": "progress-bar.js",
+  "main": "index.js",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "standard && tap test/*.js --coverage"
   },
   "repository": {
     "type": "git",
@@ -22,13 +22,18 @@
   },
   "homepage": "https://github.com/iarna/gauge",
   "dependencies": {
-    "ansi": "^0.3.0",
+    "aproba": "^1.0.1",
+    "has-color": "^0.1.7",
     "has-unicode": "^2.0.0",
-    "lodash.pad": "^4.1.0",
-    "lodash.padend": "^4.1.0",
-    "lodash.padstart": "^4.1.0"
+    "object-assign": "^4.0.1",
+    "string-width": "^1.0.1",
+    "strip-ansi": "^3.0.0",
+    "wide-align": "^1.1.0"
   },
   "devDependencies": {
-    "tap": "^5.6.0"
+    "require-inject": "^1.3.0",
+    "standard": "^6.0.7",
+    "tap": "^5.6.0",
+    "through2": "^2.0.0"
   }
 }

--- a/plumbing.js
+++ b/plumbing.js
@@ -1,0 +1,45 @@
+'use strict'
+var consoleStrings = require('./console-strings.js')
+var renderTemplate = require('./render-template.js')
+var validate = require('aproba')
+
+var Plumbing = module.exports = function (theme, template, width) {
+  if (!width) width = 80
+  validate('OAN', [theme, template, width])
+  this.showing = false
+  this.theme = theme
+  this.width = width
+  this.template = template
+}
+Plumbing.prototype = {}
+
+Plumbing.prototype.setTheme = function (theme) {
+  validate('O', [theme])
+  this.theme = theme
+}
+
+Plumbing.prototype.setTemplate = function (template) {
+  validate('A', [template])
+  this.template = template
+}
+
+Plumbing.prototype.setWidth = function (width) {
+  validate('N', [width])
+  this.width = width
+}
+
+Plumbing.prototype.hide = function () {
+  return '\r' + consoleStrings.eraseLine()
+}
+
+Plumbing.prototype.hideCursor = consoleStrings.hideCursor
+
+Plumbing.prototype.showCursor = consoleStrings.showCursor
+
+Plumbing.prototype.show = function (status) {
+  var values = Object.create(this.theme)
+  Object.keys(status).forEach(function (key) { values[key] = status[key] })
+
+  return renderTemplate(this.width, this.template, values) +
+         consoleStrings.eraseLine() + '\r'
+}

--- a/progress-bar.js
+++ b/progress-bar.js
@@ -1,225 +1,35 @@
-"use strict"
-var hasUnicode = require("has-unicode")
-var ansi = require("ansi")
-var align = {
-  center: require("lodash.pad"),
-  left:   require("lodash.padend"),
-  right:  require("lodash.padstart")
-}
-var defaultStream = process.stderr
-function isTTY() {
-  return process.stderr.isTTY
-}
-function getWritableTTYColumns() {
-  // Writing to the final column wraps the line
-  // We have to use stdout here, because Node's magic SIGWINCH handler only
-  // updates process.stdout, not process.stderr
-  return process.stdout.columns - 1
-}
+'use strict'
+var validate = require('aproba')
+var renderTemplate = require('./render-template.js')
+var wideTruncate = require('./wide-truncate')
+var stringWidth = require('string-width')
 
-var ProgressBar = module.exports = function (options, cursor) {
-  if (! options) options = {}
-  if (! cursor && options.write) {
-    cursor = options
-    options = {}
-  }
-  if (! cursor) {
-    cursor = ansi(defaultStream)
-  }
-  this.cursor = cursor
-  this.showing = false
-  this.theme = options.theme || (hasUnicode() ? ProgressBar.unicode : ProgressBar.ascii)
-  this.template = options.template || [
-    {type: "name", separated: true, length: 25},
-    {type: "spinner", separated: true},
-    {type: "startgroup"},
-    {type: "completionbar"},
-    {type: "endgroup"}
+module.exports = function (theme, width, completed) {
+  validate('ONN', [theme, width, completed])
+  if (completed < 0) completed = 0
+  if (completed > 1) completed = 1
+  if (width <= 0) return ''
+  var sofar = Math.round(width * completed)
+  var rest = width - sofar
+  var template = [
+    {type: 'complete', value: repeat(theme.complete, sofar), length: sofar},
+    {type: 'remaining', value: repeat(theme.remaining, rest), length: rest}
   ]
-  this.updatefreq = options.maxUpdateFrequency == null ? 50 : options.maxUpdateFrequency
-  this.lastName = ""
-  this.lastCompleted = 0
-  this.spun = 0
-  this.last = new Date(0)
-
-  var self = this
-  this._handleSizeChange = function () {
-    if (!self.showing) return
-    self.hide()
-    self.show()
-  }
-}
-ProgressBar.prototype = {}
-
-ProgressBar.unicode = {
-  startgroup: "╢",
-  endgroup: "╟",
-  complete: "█",
-  incomplete: "░",
-  spinner: "▀▐▄▌",
-  subsection: "→"
+  return renderTemplate(width, template, theme)
 }
 
-ProgressBar.ascii = {
-  startgroup: "|",
-  endgroup: "|",
-  complete: "#",
-  incomplete: "-",
-  spinner: "-\\|/",
-  subsection: "->"
-}
-
-ProgressBar.prototype.setTheme = function(theme) {
-  this.theme = theme
-}
-
-ProgressBar.prototype.setTemplate = function(template) {
-  this.template = template
-}
-
-ProgressBar.prototype._enableResizeEvents = function() {
-  process.stdout.on('resize', this._handleSizeChange)
-}
-
-ProgressBar.prototype._disableResizeEvents = function() {
-  process.stdout.removeListener('resize', this._handleSizeChange)
-}
-
-ProgressBar.prototype.disable = function() {
-  this.hide()
-  this.disabled = true
-}
-
-ProgressBar.prototype.enable = function() {
-  this.disabled = false
-  this.show()
-}
-
-ProgressBar.prototype.hide = function() {
-  if (!isTTY()) return
-  if (this.disabled) return
-  this.cursor.show()
-  if (this.showing) this.cursor.up(1)
-  this.cursor.horizontalAbsolute(0).eraseLine()
-  this.showing = false
-}
-
-var repeat = function (str, count) {
-  var out = ""
-  for (var ii=0; ii<count; ++ii) out += str
-  return out
-}
-
-ProgressBar.prototype.pulse = function(name) {
-  ++ this.spun
-  if (! this.showing) return
-  if (this.disabled) return
-
-  var baseName = this.lastName
-  name = name
-       ? ( baseName
-         ? baseName + " " + this.theme.subsection + " " + name
-         : null )
-       : baseName
-  this.show(name)
-  this.lastName = baseName
-}
-
-ProgressBar.prototype.show = function(name, completed) {
-  name = this.lastName = name || this.lastName
-  completed = this.lastCompleted = completed || this.lastCompleted
-
-  if (!isTTY()) return
-  if (this.disabled) return
-  if (! this.spun && ! completed) return
-  if (this.tryAgain) return
-  var self = this
-
-  if (this.showing && new Date() - this.last < this.updatefreq) {
-    this.tryAgain = setTimeout(function () {
-      self.tryAgain = null
-      if (self.disabled) return
-      if (! self.spun && ! completed) return
-      drawBar()
-    }, this.updatefreq - (new Date() - this.last))
-    return
-  }
-
-  return drawBar()
-
-  function drawBar() {
-    var values = {
-      name: name,
-      spinner: self.spun,
-      completed: completed
+// lodash's way of repeating
+function repeat (string, width) {
+  var result = ''
+  var n = width
+  do {
+    if (n % 2) {
+      result += string
     }
+    n = Math.floor(n / 2)
+    /*eslint no-self-assign: 0*/
+    string += string
+  } while (n && stringWidth(result) < width)
 
-    self.last = new Date()
-
-    var statusline = self.renderTemplate(self.theme, self.template, values)
-
-    if (self.showing) self.cursor.up(1)
-    self.cursor
-        .hide()
-        .horizontalAbsolute(0)
-        .write(statusline.substr(0, getWritableTTYColumns()) + "\n")
-        .show()
-
-    self.showing = true
-  }
-}
-
-ProgressBar.prototype.renderTemplate = function (theme, template, values) {
-  values.startgroup = theme.startgroup
-  values.endgroup = theme.endgroup
-  values.spinner = values.spinner
-    ? theme.spinner.substr(values.spinner % theme.spinner.length,1)
-    : ""
-
-  var output = {prebar: "", postbar: ""}
-  var status = "prebar"
-  var self = this
-  template.forEach(function(T) {
-    if (typeof T === "string") {
-      output[status] += T
-      return
-    }
-    if (T.type === "completionbar") {
-      status = "postbar"
-      return
-    }
-    if (!values.hasOwnProperty(T.type)) throw new Error("Unknown template value '"+T.type+"'")
-    var value = self.renderValue(T, values[T.type])
-    if (value === "") return
-    var sofar = output[status].length
-    var lastChar = sofar ? output[status][sofar-1] : null
-    if (T.separated && sofar && lastChar !== " ") {
-      output[status] += " "
-    }
-    output[status] += value
-    if (T.separated) output[status] += " "
-  })
-
-  var bar = ""
-  if (status === "postbar") {
-    var nonBarLen = output.prebar.length + output.postbar.length
-
-    var barLen = getWritableTTYColumns() - nonBarLen
-    var sofar = Math.round(barLen * Math.max(0,Math.min(1,values.completed||0)))
-    var rest = barLen - sofar
-    bar = repeat(theme.complete, sofar)
-        + repeat(theme.incomplete, rest)
-  }
-
-  return output.prebar + bar + output.postbar
-}
-ProgressBar.prototype.renderValue = function (template, value) {
-  if (value == null || value === "") return ""
-  var maxLength = template.maxLength || template.length
-  var minLength = template.minLength || template.length
-  var alignWith = align[template.align] || align.left
-//  if (maxLength) value = value.substr(-1 * maxLength)
-  if (maxLength) value = value.substr(0, maxLength)
-  if (minLength) value = alignWith(value, minLength)
-  return value
+  return wideTruncate(result, width)
 }

--- a/render-template.js
+++ b/render-template.js
@@ -1,0 +1,174 @@
+'use strict'
+var align = require('wide-align')
+var validate = require('aproba')
+var objectAssign = require('object-assign')
+var wideTruncate = require('./wide-truncate')
+var error = require('./error')
+var TemplateItem = require('./template-item')
+
+function renderValueWithValues (values) {
+  return function (item) {
+    return renderValue(item, values)
+  }
+}
+
+var renderTemplate = module.exports = function (width, template, values) {
+  var items = prepareItems(width, template, values)
+  var rendered = items.map(renderValueWithValues(values)).join('')
+  return align.left(wideTruncate(rendered, width), width)
+}
+
+function preType (item) {
+  var cappedTypeName = item.type[0].toUpperCase() + item.type.slice(1)
+  return 'pre' + cappedTypeName
+}
+
+function postType (item) {
+  var cappedTypeName = item.type[0].toUpperCase() + item.type.slice(1)
+  return 'post' + cappedTypeName
+}
+
+function hasPreOrPost (item, values) {
+  if (!item.type) return
+  return values[preType(item)] || values[postType(item)]
+}
+
+function generatePreAndPost (baseItem, parentValues) {
+  var item = objectAssign({}, baseItem)
+  var values = Object.create(parentValues)
+  var template = []
+  var pre = preType(item)
+  var post = postType(item)
+  if (values[pre]) {
+    template.push({value: values[pre]})
+    values[pre] = null
+  }
+  item.minLength = null
+  item.length = null
+  item.maxLength = null
+  template.push(item)
+  values[item.type] = values[item.type]
+  if (values[post]) {
+    template.push({value: values[post]})
+    values[post] = null
+  }
+  return function ($1, $2, length) {
+    return renderTemplate(length, template, values)
+  }
+}
+
+function prepareItems (width, template, values) {
+  function cloneAndObjectify (item, index, arr) {
+    var cloned = new TemplateItem(item, width)
+    var type = cloned.type
+    if (cloned.value == null) {
+      if (!(type in values)) throw new error.MissingTemplateValue(cloned, values)
+      cloned.value = values[type]
+    }
+    if (cloned.value == null || cloned.value === '') return null
+    cloned.index = index
+    cloned.first = index === 0
+    cloned.last = index === arr.length - 1
+    if (hasPreOrPost(cloned, values)) cloned.value = generatePreAndPost(cloned, values)
+    return cloned
+  }
+
+  var output = template.map(cloneAndObjectify).filter(function (item) { return item != null })
+
+  var outputLength = 0
+  var remainingSpace = width
+  var variableCount = output.length
+
+  function consumeSpace (length) {
+    if (length > remainingSpace) length = remainingSpace
+    outputLength += length
+    remainingSpace -= length
+  }
+
+  function finishSizing (item, length) {
+    if (item.finished) throw new error.Internal('Tried to finish template item that was already finished')
+    if (length === Infinity) throw new error.Internal('Length of template item cannot be infinity')
+    if (length != null) item.length = length
+    item.minLength = null
+    item.maxLength = null
+    --variableCount
+    item.finished = true
+    if (item.length == null) item.length = item.getBaseLength()
+    if (item.length == null) throw new error.Internal('Finished template items must have a length')
+    consumeSpace(item.getLength())
+  }
+
+  output.forEach(function (item) {
+    if (!item.kerning) return
+    var prevPadRight = item.first ? 0 : output[item.index - 1].padRight
+    if (!item.first && prevPadRight < item.kerning) item.padLeft = item.kerning - prevPadRight
+    if (!item.last) item.padRight = item.kerning
+  })
+
+  // Finish any that have a fixed (literal or intuited) length
+  output.forEach(function (item) {
+    if (item.getBaseLength() == null) return
+    finishSizing(item)
+  })
+
+  var resized = 0
+  var resizing
+  var hunkSize
+  do {
+    resizing = false
+    hunkSize = Math.round(remainingSpace / variableCount)
+    output.forEach(function (item) {
+      if (item.finished) return
+      if (!item.maxLength) return
+      if (item.getMaxLength() < hunkSize) {
+        finishSizing(item, item.maxLength)
+        resizing = true
+      }
+    })
+  } while (resizing && resized++ < output.length)
+  if (resizing) throw new error.Internal('Resize loop iterated too many times while determining maxLength')
+
+  resized = 0
+  do {
+    resizing = false
+    hunkSize = Math.round(remainingSpace / variableCount)
+    output.forEach(function (item) {
+      if (item.finished) return
+      if (!item.minLength) return
+      if (item.getMinLength() >= hunkSize) {
+        finishSizing(item, item.minLength)
+        resizing = true
+      }
+    })
+  } while (resizing && resized++ < output.length)
+  if (resizing) throw new error.Internal('Resize loop iterated too many times while determining minLength')
+
+  hunkSize = Math.round(remainingSpace / variableCount)
+  output.forEach(function (item) {
+    if (item.finished) return
+    finishSizing(item, hunkSize)
+  })
+
+  return output
+}
+
+function renderFunction (item, values, length) {
+  validate('OON', arguments)
+  if (item.type) {
+    return item.value(values, values[item.type + 'Theme'] || {}, length)
+  } else {
+    return item.value(values, {}, length)
+  }
+}
+
+function renderValue (item, values) {
+  var length = item.getBaseLength()
+  var value = typeof item.value === 'function' ? renderFunction(item, values, length) : item.value
+  if (value == null || value === '') return ''
+  var alignWith = align[item.align] || align.left
+  var leftPadding = item.padLeft ? align.left('', item.padLeft) : ''
+  var rightPadding = item.padRight ? align.right('', item.padRight) : ''
+  var truncated = wideTruncate(String(value), length)
+  var aligned = alignWith(truncated, length)
+  return leftPadding + aligned + rightPadding
+}

--- a/spin.js
+++ b/spin.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function spin (spinstr, spun) {
+  return spinstr[spun % spinstr.length]
+}

--- a/template-item.js
+++ b/template-item.js
@@ -1,0 +1,73 @@
+'use strict'
+var stringWidth = require('string-width')
+
+module.exports = TemplateItem
+
+function isPercent (num) {
+  if (typeof num !== 'string') return false
+  return num.slice(-1) === '%'
+}
+
+function percent (num) {
+  return Number(num.slice(0, -1)) / 100
+}
+
+function TemplateItem (values, outputLength) {
+  this.overallOutputLength = outputLength
+  this.finished = false
+  this.type = null
+  this.value = null
+  this.length = null
+  this.maxLength = null
+  this.minLength = null
+  this.kerning = null
+  this.align = 'left'
+  this.padLeft = 0
+  this.padRight = 0
+  this.index = null
+  this.first = null
+  this.last = null
+  if (typeof values === 'string') {
+    this.value = values
+  } else {
+    for (var prop in values) this[prop] = values[prop]
+  }
+  // Realize percents
+  if (isPercent(this.length)) {
+    this.length = Math.round(this.overallOutputLength * percent(this.length))
+  }
+  if (isPercent(this.minLength)) {
+    this.minLength = Math.round(this.overallOutputLength * percent(this.minLength))
+  }
+  if (isPercent(this.maxLength)) {
+    this.maxLength = Math.round(this.overallOutputLength * percent(this.maxLength))
+  }
+  return this
+}
+
+TemplateItem.prototype = {}
+
+TemplateItem.prototype.getBaseLength = function () {
+  var length = this.length
+  if (length == null && typeof this.value === 'string' && this.maxLength == null && this.minLength == null) {
+    length = stringWidth(this.value)
+  }
+  return length
+}
+
+TemplateItem.prototype.getLength = function () {
+  var length = this.getBaseLength()
+  if (length == null) return
+  return length + this.padLeft + this.padRight
+}
+
+TemplateItem.prototype.getMaxLength = function () {
+  if (this.maxLength == null) return
+  return this.maxLength + this.padLeft + this.padRight
+}
+
+TemplateItem.prototype.getMinLength = function () {
+  if (this.minLength == null) return
+  return this.minLength + this.padLeft + this.padRight
+}
+

--- a/test/console-strings.js
+++ b/test/console-strings.js
@@ -1,0 +1,44 @@
+'use strict'
+var test = require('tap').test
+var consoleStrings = require('../console-strings.js')
+
+test('consoleStrings', function (t) {
+  var oneoptarg = {
+    up: 'A',
+    down: 'B',
+    forward: 'C',
+    back: 'D',
+    nextLine: 'E',
+    previousLine: 'F'
+  }
+  Object.keys(oneoptarg).forEach(function (move) {
+    t.is(consoleStrings[move](), '\x1b[' + oneoptarg[move], move)
+    t.is(consoleStrings[move](10), '\x1b[10' + oneoptarg[move], move + ' 10')
+  })
+  var noargs = {
+    eraseData: 'J',
+    eraseLine: 'K',
+    hideCursor: '?25l',
+    showCursor: '?25h'
+  }
+  Object.keys(noargs).forEach(function (move) {
+    t.is(consoleStrings[move](), '\x1b[' + noargs[move], move)
+  })
+  t.is(consoleStrings.horizontalAbsolute(10), '\x1b[10G', 'horizontalAbsolute 10')
+  t.is(consoleStrings.horizontalAbsolute(0), '\x1b[0G', 'horizontalAbsolute 0')
+  try {
+    consoleStrings.horizontalAbsolute()
+    t.fail('horizontalAbsolute')
+  } catch (e) {
+    t.pass('horizontalAbsolute')
+  }
+  t.is(consoleStrings.color('bold', 'white', 'bgBlue'), '\x1b[1;37;44m', 'set color')
+  try {
+    consoleStrings.color('bold', 'invalid', 'blue')
+    t.fail('set invalid color')
+  } catch (e) {
+    t.pass('set invalid color')
+  }
+  t.is(consoleStrings.goto(10, 3), '\x1b[3;10H', 'absolute position')
+  t.done()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,154 @@
+'use strict'
+var test = require('tap').test
+var Gauge = require('../index')
+var stream = require('readable-stream')
+var util = require('util')
+var EventEmitter = require('event-emitter')
+
+function Sink () {
+  stream.Writable.call(this, arguments)
+}
+util.inherits(Sink, stream.Writable)
+Sink.prototype._write = function (data, enc, cb) { cb() }
+
+var results = new EventEmitter()
+function MockPlumbing (theme, template, columns) {
+  results.theme = theme
+  results.template = template
+  results.columns = columns
+  results.emit('new', theme, template, columns)
+}
+MockPlumbing.prototype = {}
+
+function RecordCall (name) {
+  return function () {
+    var args = Array.prototype.slice.call(arguments)
+    results.emit('called:' + name, args)
+    return ''
+  }
+}
+
+;['setTheme', 'setTemplate', 'setWidth', 'hide', 'show', 'hideCursor', 'showCursor'].forEach(function (fn) {
+  MockPlumbing.prototype[fn] = RecordCall(fn)
+})
+
+test('defaults', function (t) {
+  var gauge = new Gauge(process.stdout)
+  t.is(gauge.disabled, false, 'disabled')
+  t.is(gauge.updateInterval, 50, 'updateInterval')
+  if (process.stdout.isTTY) {
+    t.is(gauge.tty, process.stdout, 'tty')
+    gauge.disable()
+    gauge = new Gauge(process.stderr)
+    t.is(gauge.tty, process.stdout, 'tty is stdout when writeTo is stderr')
+  }
+  gauge.disable()
+  gauge = new Gauge(new Sink())
+  t.is(gauge.tty, undefined, 'non-tty stream is not tty')
+  gauge.disable()
+  t.end()
+})
+
+test('construct', function (t) {
+  var output = new Sink()
+  output.isTTY = true
+  output.columns = 16
+  var gauge = new Gauge(output, {
+    Plumbing: MockPlumbing,
+    theme: 'THEME',
+    template: 'TEMPLATE',
+    enabled: false
+  })
+  t.ok(gauge)
+  t.is(results.columns, 15, 'width passed through')
+  t.is(results.theme, 'THEME', 'theme passed through')
+  t.is(results.template, 'TEMPLATE', 'template passed through')
+  t.done()
+})
+
+test('show & pulse: fixedframerate', function (t) {
+  t.plan(3)
+  // this helps us abort if something never emits an event
+  // it also keeps things alive long enough to actually get output =D
+  var testtimeout = setTimeout(function () {
+    t.end()
+  }, 1000)
+  var output = new Sink()
+  output.isTTY = true
+  output.columns = 16
+  var gauge = new Gauge(output, {
+    Plumbing: MockPlumbing,
+    updateInterval: 10,
+    fixedFramerate: true
+  })
+  gauge.show('NAME', 0.1)
+  results.once('called:show', checkBasicShow)
+  function checkBasicShow (args) {
+    t.isDeeply(args, [{ spun: 0, section: 'NAME', completed: 0.1 }], 'check basic show')
+
+    gauge.show('S')
+    gauge.pulse()
+    results.once('called:show', checkPulse)
+  }
+  function checkPulse (args) {
+    t.isDeeply(args, [
+      { spun: 1, section: 'S', subsection: undefined, completed: 0.1 }
+    ], 'check pulse')
+
+    gauge.pulse('P')
+    results.once('called:show', checkPulseWithArg)
+  }
+  function checkPulseWithArg (args) {
+    t.isDeeply(args, [
+      { spun: 2, section: 'S', subsection: 'P', completed: 0.1 }
+    ], 'check pulse w/ arg')
+
+    gauge.disable()
+    clearTimeout(testtimeout)
+    t.done()
+  }
+})
+
+test('window resizing', function (t) {
+  var testtimeout = setTimeout(function () {
+    t.end()
+  }, 1000)
+  var output = new Sink()
+  output.isTTY = true
+  output.columns = 32
+
+  var gauge = new Gauge(output, {
+    Plumbing: MockPlumbing,
+    updateInterval: 0,
+    fixedFramerate: true
+  })
+  gauge.show('NAME', 0.1)
+
+  results.once('called:show', function (args) {
+    t.isDeeply(args, [{
+      section: 'NAME',
+      completed: 0.1,
+      spun: 0
+    }])
+
+    results.once('called:setWidth', lookForResize)
+
+    output.columns = 16
+    output.emit('resize')
+    gauge.show('NAME', 0.5)
+  })
+  function lookForResize (args) {
+    t.isDeeply(args, [15])
+    results.once('called:show', lookForShow)
+  }
+  function lookForShow (args) {
+    t.isDeeply(args, [{
+      section: 'NAME',
+      completed: 0.5,
+      spun: 0
+    }])
+    gauge.disable()
+    clearTimeout(testtimeout)
+    t.done()
+  }
+})

--- a/test/plumbing.js
+++ b/test/plumbing.js
@@ -1,0 +1,35 @@
+'use strict'
+var test = require('tap').test
+var stripAnsi = require('strip-ansi')
+var Plumbing = require('../plumbing.js')
+var themes = require('../themes.js')
+
+var stripInvisible = function (str) {
+  return stripAnsi(str).replace(/^\s+|\s+$/mg, '')
+}
+
+var template = [
+  {type: 'name'}
+]
+var plumbing = new Plumbing(themes.fallback.noUnicode.noColor, template, 10)
+
+// These three produce fixed strings and are entirely static, so as long as
+// they produce _something_ they're probably ok. Actually testing them will
+// require something that understands ansi codes.
+test('showCursor', function (t) {
+  t.ok(plumbing.showCursor())
+  t.end()
+})
+test('hideCursor', function (t) {
+  t.ok(plumbing.hideCursor())
+  t.end()
+})
+test('hide', function (t) {
+  t.ok(plumbing.hide())
+  t.end()
+})
+
+test('show', function (t) {
+  t.is(stripInvisible(plumbing.show({name: 'test'})), 'test')
+  t.end()
+})

--- a/test/progress-bar.js
+++ b/test/progress-bar.js
@@ -1,176 +1,42 @@
-"use strict"
-var test = require("tap").test
-var ProgressBar = require("../progress-bar.js")
+'use strict'
+var test = require('tap').test
+var progressBar = require('../progress-bar')
 
-var cursor = []
-var C
-var bar = new ProgressBar({theme: ProgressBar.ascii, maxUpdateFrequency: 0}, C = {
-  show: function () {
-    cursor.push(["show"])
-    return C
-  },
-  hide: function () {
-    cursor.push(["hide"])
-    return C
-  },
-  up: function (lines) {
-    cursor.push(["up",lines])
-    return C
-  },
-  horizontalAbsolute: function (col) {
-    cursor.push(["horizontalAbsolute", col])
-    return C
-  },
-  eraseLine: function () {
-    cursor.push(["eraseLine"])
-    return C
-  },
-  write: function (line) {
-    cursor.push(["write", line])
-    return C
+test('progressBar', function (t) {
+  var theme = {
+    complete: '#',
+    remaining: '-'
   }
-})
+  var result
+  result = progressBar(theme, 10, 0)
+  t.is(result, '----------', '0% bar')
+  result = progressBar(theme, 10, 0.5)
+  t.is(result, '#####-----', '50% bar')
+  result = progressBar(theme, 10, 1)
+  t.is(result, '##########', '100% bar')
+  result = progressBar(theme, 10, -100)
+  t.is(result, '----------', '0% underflow bar')
+  result = progressBar(theme, 10, 100)
+  t.is(result, '##########', '100% overflow bar')
+  result = progressBar(theme, 0, 0.5)
+  t.is(result, '', '0 width bar')
 
-
-function isOutput(t, msg, output) {
-  var tests = []
-  for (var ii = 0; ii<output.length; ++ii) {
-    for (var jj = 0; jj<output[ii].length; ++jj) {
-      tests.push({cmd: ii, arg: jj})
-    }
+  var multicharTheme = {
+    complete: '123',
+    remaining: 'abc'
   }
-  tests.forEach(function(test) {
-    t.is(cursor[test.cmd] ? cursor[test.cmd][test.arg] : null,
-         output[test.cmd][test.arg],
-         msg + ": " + output[test.cmd] + (test.arg ? " arg #"+test.arg : ""))
-  })
-}
+  result = progressBar(multicharTheme, 10, 0)
+  t.is(result, 'abcabcabca', '0% bar')
+  result = progressBar(multicharTheme, 10, 0.5)
+  t.is(result, '12312abcab', '50% bar')
+  result = progressBar(multicharTheme, 10, 1)
+  t.is(result, '1231231231', '100% bar')
+  result = progressBar(multicharTheme, 10, -100)
+  t.is(result, 'abcabcabca', '0% underflow bar')
+  result = progressBar(multicharTheme, 10, 100)
+  t.is(result, '1231231231', '100% overflow bar')
+  result = progressBar(multicharTheme, 0, 0.5)
+  t.is(result, '', '0 width bar')
 
-test("hide", function (t) {
-  t.plan(11)
-  process.stderr.isTTY = false
-  bar.hide()
-  t.is(cursor.length, 0, "We don't progress bar without a tty")
-  cursor = []
-  process.stderr.isTTY = true
-  bar.hide()
-  isOutput(t, "hide while not showing",[
-    ["show"], // cursor
-    ["horizontalAbsolute",0],
-    ["eraseLine"]])
-  cursor = []
-  bar.showing = true
-  bar.hide()
-  isOutput(t, "hide while showing",[
-    ["show"], // cursor
-    ["up", 1],
-    ["horizontalAbsolute",0],
-    ["eraseLine"]])
+  t.done()
 })
-
-test("renderTemplate", function (t) {
-  t.plan(16)
-  process.stdout.columns = 11
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "name"}],{name: "NAME"})
-  t.is(result, "NAME", "name substitution")
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "completionbar"}],{completed: 0})
-  t.is(result, "----------", "0% bar")
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "completionbar"}],{completed: 0.5})
-  t.is(result, "#####-----", "50% bar")
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "completionbar"}],{completed: 1})
-  t.is(result, "##########", "100% bar")
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "completionbar"}],{completed: -100})
-  t.is(result, "----------", "0% underflow bar")
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "completionbar"}],{completed: 100})
-  t.is(result, "##########", "100% overflow bar")
-  var result = bar.renderTemplate(ProgressBar.ascii,[{type: "name"},{type: "completionbar"}],{name: "NAME", completed: 0.5})
-  t.is(result, "NAME###---", "name + 50%")
-  var result = bar.renderTemplate(ProgressBar.ascii, ["static"], {})
-  t.is(result, "static", "static text")
-  var result = bar.renderTemplate(ProgressBar.ascii, ["static",{type: "name"}], {name: "NAME"})
-  t.is(result, "staticNAME", "static text + var")
-  var result = bar.renderTemplate(ProgressBar.ascii, ["static",{type: "name", separated: true}], {name: "NAME"})
-  t.is(result, "static NAME ", "pre-separated")
-  var result = bar.renderTemplate(ProgressBar.ascii, [{type: "name", separated: true}, "static"], {name: "NAME"})
-  t.is(result, "NAME static", "post-separated")
-  var result = bar.renderTemplate(ProgressBar.ascii, ["1",{type: "name", separated: true}, "2"], {name: ""})
-  t.is(result, "12", "separated no value")
-  var result = bar.renderTemplate(ProgressBar.ascii, ["1",{type: "name", separated: true}, "2"], {name: "NAME"})
-  t.is(result, "1 NAME 2", "separated value")
-  var result = bar.renderTemplate(ProgressBar.ascii, [{type: "spinner"}], {spinner: 0})
-  t.is(result, "", "No spinner")
-  var result = bar.renderTemplate(ProgressBar.ascii, [{type: "spinner"}], {spinner: 1})
-  t.is(result, "\\", "Spinner 1")
-  var result = bar.renderTemplate(ProgressBar.ascii, [{type: "spinner"}], {spinner: 10})
-  t.is(result, "|", "Spinner 10")
-})
-
-test("show & pulse", function (t) {
-  t.plan(23)
-
-  process.stdout.columns = 16
-  cursor = []
-  process.stderr.isTTY = false
-  bar.template[0].length = 6
-  bar.last = new Date(0)
-  bar.show("NAME", 0)
-  t.is(cursor.length, 0, "no tty, no progressbar")
-
-  cursor = []
-  process.stderr.isTTY = true
-  bar.last = new Date(0)
-  bar.show("NAME", 0.1)
-  isOutput(t, "tty, name, completion",
-    [ [ 'hide' ],
-      [ 'horizontalAbsolute', 0 ],
-      [ 'write', 'NAME   |#-----|\n' ],
-      [ 'show' ] ])
-
-  bar.show("S")
-  cursor = []
-  bar.last = new Date(0)
-  bar.pulse()
-  isOutput(t, "pulsed spinner",
-    [ [ 'up', 1 ],
-      [ 'hide' ],
-      [ 'horizontalAbsolute', 0 ],
-      [ 'write', 'S      \\ |----|\n' ],
-      [ 'show' ] ])
-  cursor = []
-  bar.last = new Date(0)
-  bar.pulse("P")
-  isOutput(t, "pulsed spinner with subsection",
-    [ [ 'up', 1 ],
-      [ 'hide' ],
-      [ 'horizontalAbsolute', 0 ],
-      [ 'write', 'S -> P | |----|\n' ],
-      [ 'show' ] ])
-})
-
-test("window resizing", function (t) {
-  t.plan(16)
-  process.stderr.isTTY = true
-  process.stdout.columns = 32
-  bar.show("NAME", 0.1)
-  cursor = []
-  bar.last = new Date(0)
-  bar.pulse()
-  isOutput(t, "32 columns",
-    [ [ 'up', 1 ],
-      [ 'hide' ],
-      [ 'horizontalAbsolute', 0 ],
-      [ 'write', 'NAME   / |##------------------|\n' ],
-      [ 'show' ] ])
-
-  process.stdout.columns = 16
-  bar.show("NAME", 0.5)
-  cursor = []
-  bar.last = new Date(0)
-  bar.pulse()
-  isOutput(t, "16 columns",
-    [ [ 'up', 1 ],
-      [ 'hide' ],
-      [ 'horizontalAbsolute', 0 ],
-      [ 'write', 'NAME   - |##--|\n' ],
-      [ 'show' ] ]);
-});

--- a/test/render-template.js
+++ b/test/render-template.js
@@ -1,0 +1,82 @@
+'use strict'
+var test = require('tap').test
+var renderTemplate = require('../render-template')
+
+test('renderTemplate', function (t) {
+  var result
+  result = renderTemplate(10, [{type: 'name'}], {name: 'NAME'})
+  t.is(result, 'NAME      ', 'name substitution')
+
+  result = renderTemplate(10,
+    [{type: 'name'}, {type: 'completionbar'}],
+    {
+      name: 'NAME',
+      completionbar: function (values, theme, width) {
+        return 'xx' + String(width) + 'xx'
+      }
+    })
+  t.is(result, 'NAMExx6xx ', 'name + 50%')
+
+  result = renderTemplate(10, ['static'], {})
+  t.is(result, 'static    ', 'static text')
+
+  result = renderTemplate(10, ['static', {type: 'name'}], {name: 'NAME'})
+  t.is(result, 'staticNAME', 'static text + var')
+
+  result = renderTemplate(10, ['static', {type: 'name', kerning: 1}], {name: 'NAME'})
+  t.is(result, 'static NAM', 'pre-separated')
+
+  result = renderTemplate(10, [{type: 'name', kerning: 1}, 'static'], {name: 'NAME'})
+  t.is(result, 'NAME stati', 'post-separated')
+
+  result = renderTemplate(10, ['1', {type: 'name', kerning: 1}, '2'], {name: ''})
+  t.is(result, '12        ', 'separated no value')
+
+  result = renderTemplate(10, ['1', {type: 'name', kerning: 1}, '2'], {name: 'NAME'})
+  t.is(result, '1 NAME 2  ', 'separated value')
+
+  result = renderTemplate(10, ['AB', {type: 'name', kerning: 1}, {value: 'CD', kerning: 1}], {name: 'NAME'})
+  t.is(result, 'AB NAME CD', 'multi kerning')
+
+  result = renderTemplate(10, [{type: 'name', length: '50%'}, 'static'], {name: 'N'})
+  t.is(result, 'N    stati', 'percent length')
+
+  try {
+    result = renderTemplate(10, [{type: 'xyzzy'}, 'static'], {})
+    t.fail('missing type')
+  } catch (e) {
+    t.pass('missing type')
+  }
+
+  result = renderTemplate(10, [{type: 'name', minLength: '20%'}, 'this long thing'], {name: 'N'})
+  t.is(result, 'N this lon', 'percent minlength')
+
+  result = renderTemplate(10, [{type: 'name', maxLength: '20%'}, 'nope'], {name: 'NAME'})
+  t.is(result, 'NAnope    ', 'percent maxlength')
+
+  result = renderTemplate(10, [{type: 'name', padLeft: 2, padRight: 2}, '||'], {name: 'NAME'})
+  t.is(result, '  NAME  ||', 'manual padding')
+
+  result = renderTemplate(10, [{value: 'ABC', minLength: 2, maxLength: 6}, 'static'], {})
+  t.is(result, 'ABC static', 'max hunk size < maxLength')
+
+  result = renderTemplate(10, [{value: function () { return '' }}], {})
+  t.is(result, '          ', 'empty value')
+
+  result = renderTemplate(10, [{value: '12古34', align: 'center', length: '100%'}], {})
+  t.is(result, '  12古34  ', 'wide chars')
+
+  result = renderTemplate(10, [{type: 'test', value: 'abc'}], {preTest: '¡', postTest: '!'})
+  t.is(result, '¡abc!     ', 'pre/post values')
+
+  result = renderTemplate(10, [{type: 'test', value: 'abc'}], {preTest: '¡'})
+  t.is(result, '¡abc      ', 'pre values')
+
+  result = renderTemplate(10, [{type: 'test', value: 'abc'}], {postTest: '!'})
+  t.is(result, 'abc!      ', 'post values')
+
+  result = renderTemplate(10, [{value: 'abc'}, {value: '‼‼', length: 0}, {value: 'def'}])
+  t.is(result, 'abcdef    ', 'post values')
+
+  t.end()
+})

--- a/test/spin.js
+++ b/test/spin.js
@@ -1,0 +1,13 @@
+'use strict'
+var test = require('tap').test
+var spin = require('../spin')
+
+test('spin', function (t) {
+  t.plan(2)
+  var spinner = '123456'
+  var result
+  result = spin(spinner, 1)
+  t.is(result, '2', 'Spinner 1')
+  result = spin(spinner, 10)
+  t.is(result, '5', 'Spinner 10')
+})

--- a/test/themes.js
+++ b/test/themes.js
@@ -1,0 +1,34 @@
+'use strict'
+var test = require('tap').test
+var themes = require('../themes.js')
+
+test('themes', function (t) {
+  Object.keys(themes).forEach(function (platform) {
+    if (typeof themes[platform] === 'function') return
+    var platformThemeGroup = themes[platform]
+    ;['hasUnicode', 'noUnicode'].forEach(function (unicode) {
+      var unicodeThemeGroup = platformThemeGroup[unicode]
+      if (t.ok(unicodeThemeGroup, platform + ' has theming for ' + unicode)) {
+        ['hasColor', 'noColor'].forEach(function (color) {
+          var colorTheme = unicodeThemeGroup[color]
+          t.ok(colorTheme, platform + ' ' + unicode + ' has theming for ' + color)
+        })
+      }
+    })
+  })
+  t.end()
+})
+
+test('selector', function (t) {
+  t.is(themes({hasUnicode: false, hasColor: false, platform: 'unknown'}), themes.fallback.noUnicode.noColor, 'fallback')
+  t.is(themes({hasUnicode: false, hasColor: false, platform: 'darwin'}), themes.darwin.noUnicode.noColor, 'ff darwin')
+  t.is(themes({hasUnicode: true, hasColor: false, platform: 'darwin'}), themes.darwin.hasUnicode.noColor, 'tf drawin')
+  t.is(themes({hasUnicode: false, hasColor: true, platform: 'darwin'}), themes.darwin.noUnicode.hasColor, 'ft darwin')
+  var theme = themes[process.platform] || themes.fallback
+  t.is(themes({hasUnicode: true, hasColor: true}), theme.hasUnicode.hasColor, 'tt')
+  t.end()
+})
+
+test('newTheme', function (t) {
+  t.end()
+})

--- a/test/wide-truncate.js
+++ b/test/wide-truncate.js
@@ -1,0 +1,48 @@
+'use strict'
+var test = require('tap').test
+var wideTruncate = require('../wide-truncate.js')
+
+test('wideTruncate', function (t) {
+  var result
+
+  result = wideTruncate('abc', 6)
+  t.is(result, 'abc', 'narrow, no truncation')
+  result = wideTruncate('古古古', 6)
+  t.is(result, '古古古', 'wide, no truncation')
+  result = wideTruncate('abc', 2)
+  t.is(result, 'ab', 'narrow, truncation')
+  result = wideTruncate('古古古', 2)
+  t.is(result, '古', 'wide, truncation')
+  result = wideTruncate('古古', 3)
+  t.is(result, '古', 'wide, truncation, partial')
+  result = wideTruncate('古', 1)
+  t.is(result, '', 'wide, truncation, no chars fit')
+  result = wideTruncate('abc', 0)
+  t.is(result, '', 'zero truncation is empty')
+  result = wideTruncate('', 10)
+  t.is(result, '', 'empty string')
+
+  result = wideTruncate('abc古古古def', 12)
+  t.is(result, 'abc古古古def', 'mixed nwn, no truncation')
+  result = wideTruncate('abcdef古古古', 12)
+  t.is(result, 'abcdef古古古', 'mixed nw, no truncation')
+  result = wideTruncate('古古古abcdef', 12)
+  t.is(result, '古古古abcdef', 'mixed wn, no truncation')
+  result = wideTruncate('古古abcdef古', 12)
+  t.is(result, '古古abcdef古', 'mixed wnw, no truncation')
+
+  result = wideTruncate('abc古古古def', 6)
+  t.is(result, 'abc古', 'mixed nwn, truncation')
+  result = wideTruncate('abcdef古古古', 6)
+  t.is(result, 'abcdef', 'mixed nw, truncation')
+  result = wideTruncate('古古古abcdef', 6)
+  t.is(result, '古古古', 'mixed wn, truncation')
+  result = wideTruncate('古古abcdef古', 6)
+  t.is(result, '古古ab', 'mixed wnw, truncation')
+  result = wideTruncate('abc\x1b[0mdef', 6)
+  t.is(result, 'abc\x1b[0mdef', 'ansi codes are zero width')
+  result = wideTruncate('abc\x1b[0mdef', 4)
+  t.is(result, 'abc\x1b[0md', 'ansi codes are zero width, clip text')
+
+  t.end()
+})

--- a/themes.js
+++ b/themes.js
@@ -1,0 +1,85 @@
+'use strict'
+var validate = require('aproba')
+var objectAssign = require('object-assign')
+var consoleStrings = require('./console-strings')
+var spin = require('./spin.js')
+var progressBar = require('./progress-bar.js')
+
+var themes = module.exports = function (opts) {
+  if (!opts) opts = {}
+  var os = themes[opts.platform || process.platform] || themes.fallback
+  var unicode = opts.hasUnicode ? os.hasUnicode : os.noUnicode
+  var color = opts.hasColor ? unicode.hasColor : unicode.noColor
+  return color
+}
+
+var baseTheme = {
+  activityIndicator: function (values, theme, width) {
+    if (values.spun == null) return
+    return spin(theme, values.spun)
+  },
+  progressbar: function (values, theme, width) {
+    if (values.completed == null) return
+    return progressBar(theme, width, values.completed)
+  }
+}
+
+var newTheme = themes.newTheme = function (parent, theme) {
+  if (!theme) {
+    theme = parent
+    parent = baseTheme
+  }
+  validate('OO', [parent, theme])
+  return objectAssign({}, parent, theme)
+}
+
+themes.fallback = {}
+themes.fallback.noUnicode = {}
+themes.fallback.noUnicode.noColor = newTheme({
+  preProgressbar: '[',
+  postProgressbar: ']',
+  progressbarTheme: {
+    complete: '#',
+    remaining: '-'
+  },
+  activityIndicatorTheme: '-\\|/',
+  preSubsection: '/'
+})
+
+themes.fallback.noUnicode.hasColor = newTheme(themes.fallback.noUnicode.noColor, {
+  progressbarTheme: {
+    preComplete: consoleStrings.color('inverse'),
+    complete: ' ',
+    postComplete: consoleStrings.color('stopInverse'),
+    preRemaining: consoleStrings.color('brightBlack'),
+    remaining: '░',
+    postRemaining: consoleStrings.color('reset')
+  }
+})
+
+themes.fallback.hasUnicode = themes.fallback.noUnicode
+
+themes.darwin = {}
+themes.darwin.noUnicode = themes.fallback.noUnicode
+themes.darwin.hasUnicode = {}
+themes.darwin.hasUnicode.noColor = newTheme({
+  preProgressbar: '«',
+  postProgressbar: '»',
+  preSubsection: '⁄',
+  progressbarTheme: {
+    complete: '░',
+    remaining: '-'
+  },
+  activityIndicatorTheme: '◷◶◵◴'
+})
+
+themes.darwin.hasUnicode.hasColor = newTheme(themes.darwin.hasUnicode.noColor, {
+  progressbarTheme: {
+    preComplete: consoleStrings.color('inverse'),
+    complete: ' ',
+    postComplete: consoleStrings.color('stopInverse'),
+    preRemaining: consoleStrings.color('brightBlack'),
+    remaining: '░',
+    postRemaining: consoleStrings.color('reset')
+  }
+})

--- a/wide-truncate.js
+++ b/wide-truncate.js
@@ -1,0 +1,25 @@
+'use strict'
+var stringWidth = require('string-width')
+var stripAnsi = require('strip-ansi')
+
+module.exports = wideTruncate
+
+function wideTruncate (str, target) {
+  if (stringWidth(str) === 0) return str
+  if (target <= 0) return ''
+  if (stringWidth(str) <= target) return str
+
+  // We compute the number of bytes of ansi sequences here and add
+  // that to our initial truncation to ensure that we don't slice one
+  // that we want to keep in half.
+  var noAnsi = stripAnsi(str)
+  var ansiSize = str.length + noAnsi.length
+  var truncated = str.slice(0, target + ansiSize)
+
+  // we have to shrink the result to account for our ansi sequence buffer
+  // (if an ansi sequence was truncated) and double width characters.
+  while (stringWidth(truncated) > target) {
+    truncated = truncated.slice(0, -1)
+  }
+  return truncated
+}


### PR DESCRIPTION
So I've been working on a `gauge@2.0.0` that just returns a string that you could print, but doesn't write anything to any streams itself– it also moves various "interrogate the environment" type things to be just defaults, rather than something it has to do for itself, which means consumers can more easily override these.

Also it means easy unit testing!

This branch will be ready when:
1. [x] Coverage is gud.
2. [x] All of the ANSI codes in `console-strings.js` (borrowed from `ansi`) have been tested against popular Windows terminals.
3. [x] A number of example themes have been produced (and unicode detection ditched as a concern for gauge itself.)
4. [x] Documentation has been updated. Especially around the changes to the template language.
