### PR TITLE
deps: update lodash deps to v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "ansi": "^0.3.0",
     "has-unicode": "^2.0.0",
-    "lodash.pad": "^3.0.0",
-    "lodash.padleft": "^3.0.0",
-    "lodash.padright": "^3.0.0"
+    "lodash.pad": "^3.3.0",
+    "lodash.padend": "^4.1.0",
+    "lodash.padstart": "^4.1.0"
   },
   "devDependencies": {
     "tap": "^0.4.13"

--- a/progress-bar.js
+++ b/progress-bar.js
@@ -3,8 +3,8 @@ var hasUnicode = require("has-unicode")
 var ansi = require("ansi")
 var align = {
   center: require("lodash.pad"),
-  left:   require("lodash.padright"),
-  right:  require("lodash.padleft")
+  left:   require("lodash.padend"),
+  right:  require("lodash.padstart")
 }
 var defaultStream = process.stderr
 function isTTY() {


### PR DESCRIPTION
Lodash v3 is no longer being supported.

lodash.padright is now lodash.padstart
lodash.padleft is now lodash.padend

Update dependencies and modify require's as neccessary
