### PR TITLE
lodash.padright deprecated -> lodash.padend

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "has-unicode": "^2.0.0",
     "lodash.pad": "^3.0.0",
     "lodash.padleft": "^3.0.0",
-    "lodash.padright": "^3.0.0"
+    "lodash.padend": "^4.0.0"
   },
   "devDependencies": {
     "tap": "^0.4.13"

--- a/progress-bar.js
+++ b/progress-bar.js
@@ -3,7 +3,7 @@ var hasUnicode = require("has-unicode")
 var ansi = require("ansi")
 var align = {
   center: require("lodash.pad"),
-  left:   require("lodash.padright"),
+  left:   require("lodash.padend"),
   right:  require("lodash.padleft")
 }
 var defaultStream = process.stderr


### PR DESCRIPTION
Gets rid of the following warning:

```
npm WARN deprecated lodash.padright@3.1.1: This package has been renamed. Use lodash.padend@^4.0.0.
```
