### PR TITLE
Add signal-exit to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "has-color": "^0.1.7",
     "has-unicode": "^2.0.0",
     "object-assign": "^4.0.1",
+    "signal-exit": "^2.1.2",
     "string-width": "^1.0.1",
     "strip-ansi": "^3.0.0",
     "wide-align": "^1.1.0"


### PR DESCRIPTION
`require()`ed in `index.js` but not defined as a dependency.

``` sh
$ npm install gauge@2.0.0
$ node
> require('gauge')
Error: Cannot find module 'signal-exit'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
```
