### PR TITLE
Fix deprecated depencency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aproba": "^1.0.3",
     "console-control-strings": "^1.0.0",
-    "has-color": "^0.1.7",
+    "supports-color": "^0.2.0",
     "has-unicode": "^2.0.0",
     "object-assign": "^4.1.0",
     "signal-exit": "^3.0.0",


### PR DESCRIPTION
has-color is been renamed in supports-color
https://github.com/sindresorhus/has-color
https://github.com/chalk/supports-color
This pull fix the deprecated warning generated during the install of this package.
