### PR TITLE
Remove a redundant dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "aproba": "^1.0.3",
     "console-control-strings": "^1.0.0",
-    "has-color": "^0.1.7",
     "has-unicode": "^2.0.0",
     "object-assign": "^4.1.0",
     "signal-exit": "^3.0.0",


### PR DESCRIPTION
After reviewing `index.js` I notice that `has-color` module is not `required` any more.
[This commit](https://github.com/iarna/gauge/commit/41b9e95f39c922259652f5d00e6326e33c14b931) show that you remove `has-color` in code and docs

I think accidentally you leave it in `package` dependences and it causes this a bit annoying message appears.....

![npm warn message](https://cloud.githubusercontent.com/assets/3364271/20375677/9b9f862a-acbb-11e6-99a6-e79e0603c8bb.jpg)
