### PR TITLE
Enable 'colorBrailleSpinner' on Linux workstations

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -52,3 +52,6 @@ themes.setDefault({}, 'ASCII')
 themes.setDefault({hasColor: true}, 'colorASCII')
 themes.setDefault({platform: 'darwin', hasUnicode: true}, 'brailleSpinner')
 themes.setDefault({platform: 'darwin', hasUnicode: true, hasColor: true}, 'colorBrailleSpinner')
+themes.setDefault({platform: 'linux', hasUnicode: true}, 'brailleSpinner')
+themes.setDefault({platform: 'linux', hasUnicode: true, hasColor: true}, 'colorBrailleSpinner')
+


### PR DESCRIPTION
If a Linux workstation `hasUnicode` and `hasColor` then it should be able to use the `brailleSpinner` and `colorBrailleSpinner` by default.

References #112 