### PR TITLE
chore: update package.json

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,2 @@
+---
+_extends: 'open-source-project-boilerplate'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
+  - "12"
   - "10"
-  - "8"
-  - "6"
-  - "7"
-  - "4"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A terminal based horizontal guage",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tap test/*.js --coverage",
-    "prepublish": "rm -f *~"
+    "test": "standard && tap test/*.js --coverage"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "theme-set.js",
     "themes.js",
     "wide-truncate.js"
-  ]
+  ],
+  "engines": {
+    "node": ">=10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "author": "Rebecca Turner <me@re-becca.org>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/iarna/gauge/issues"
+    "url": "https://github.com/npm/gauge/issues"
   },
-  "homepage": "https://github.com/iarna/gauge",
+  "homepage": "https://github.com/npm/gauge",
   "dependencies": {
     "aproba": "^1.0.3 || ^2.0.0",
     "color-support": "^1.1.2",


### PR DESCRIPTION
# What / Why
Updates the homepage/bug URL to npm and drops support for node v4, v6 and v7.

