### PR TITLE
Add missing dependency object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "color-support": "^1.1.2",
     "console-control-strings": "^1.0.0",
     "has-unicode": "^2.0.1",
+    "object-assign": "^4.1.1",
     "signal-exit": "^3.0.0",
     "string-width": "^1.0.1 || ^2.0.0",
     "strip-ansi": "^3.0.1 || ^4.0.0",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Looks like object-assign is required but not installed.  It's common enough to where it's not noticed, but in some cases this causes gauge to throw.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

https://github.com/npm/gauge/blob/d10739021f85125abb04112d721d17e600746004/theme-set.js#L2
https://github.com/npm/gauge/blob/d10739021f85125abb04112d721d17e600746004/test/template-item.js#L3



