### PR TITLE
Remove remaining uses of object-assign

### DIFF
--- a/test/template-item.js
+++ b/test/template-item.js
@@ -1,6 +1,5 @@
 'use strict'
 var test = require('tap').test
-var objectAssign = require('object-assign')
 var TemplateItem = require('../template-item.js')
 
 var width = 200
@@ -26,7 +25,7 @@ function got (values) {
 }
 
 function expected (obj) {
-  return objectAssign({}, defaults, obj)
+  return Object.assign({}, defaults, obj)
 }
 
 test('new', function (t) {

--- a/theme-set.js
+++ b/theme-set.js
@@ -1,5 +1,4 @@
 'use strict'
-var objectAssign = require('object-assign')
 
 module.exports = function () {
   return ThemeSetProto.newThemeSet()
@@ -14,7 +13,7 @@ ThemeSetProto.newTheme = function (parent, theme) {
     theme = parent
     parent = this.baseTheme
   }
-  return objectAssign({}, parent, theme)
+  return Object.assign({}, parent, theme)
 }
 
 ThemeSetProto.getThemeNames = function () {
@@ -28,9 +27,9 @@ ThemeSetProto.addTheme = function (name, parent, theme) {
 ThemeSetProto.addToAllThemes = function (theme) {
   var themes = this.themes
   Object.keys(themes).forEach(function (name) {
-    objectAssign(themes[name], theme)
+    Object.assign(themes[name], theme)
   })
-  objectAssign(this.baseTheme, theme)
+  Object.assign(this.baseTheme, theme)
 }
 
 ThemeSetProto.getTheme = function (name) {
@@ -76,7 +75,7 @@ ThemeSetProto.getDefault = function (opts) {
   if (platform[hasUnicode][hasColor]) {
     return this.getTheme(platform[hasUnicode][hasColor])
   } else {
-    return this.getDefault(objectAssign({}, opts, {platform: 'fallback'}))
+    return this.getDefault(Object.assign({}, opts, {platform: 'fallback'}))
   }
 }
 
@@ -106,9 +105,9 @@ ThemeSetProto.newThemeSet = function () {
   var themeset = function (opts) {
     return themeset.getDefault(opts)
   }
-  return objectAssign(themeset, ThemeSetProto, {
-    themes: objectAssign({}, this.themes),
-    baseTheme: objectAssign({}, this.baseTheme),
+  return Object.assign(themeset, ThemeSetProto, {
+    themes: Object.assign({}, this.themes),
+    baseTheme: Object.assign({}, this.baseTheme),
     defaults: JSON.parse(JSON.stringify(this.defaults || {}))
   })
 }


### PR DESCRIPTION
Looks like object-assign was removed in #122 but it was still used in various code paths.  This replaces all remaining uses with the built in `Object.assign`.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
- Related to https://github.com/npm/gauge/pull/122
- Replaces https://github.com/npm/gauge/pull/125
