### PR TITLE
fix: remove object-assign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "gauge",
       "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
@@ -12,7 +13,6 @@
         "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
         "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
         "string-width": "^1.0.1 || ^2.0.0",
         "strip-ansi": "^3.0.1 || ^4.0.0",
@@ -2745,6 +2745,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6697,7 +6698,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "color-support": "^1.1.2",
     "console-control-strings": "^1.0.0",
     "has-unicode": "^2.0.1",
-    "object-assign": "^4.1.1",
     "signal-exit": "^3.0.0",
     "string-width": "^1.0.1 || ^2.0.0",
     "strip-ansi": "^3.0.1 || ^4.0.0",


### PR DESCRIPTION
Thanks to https://github.com/npm/gauge/pull/126 we can re-remove this
from the package.json
