### PR TITLE
fix: use more commonly available character for pre/post progressbar

### DIFF
--- a/lib/themes.js
+++ b/lib/themes.js
@@ -27,8 +27,8 @@ themes.addTheme('colorASCII', themes.getTheme('ASCII'), {
 })
 
 themes.addTheme('brailleSpinner', {
-  preProgressbar: '⸨',
-  postProgressbar: '⸩',
+  preProgressbar: '(',
+  postProgressbar: ')',
   progressbarTheme: {
     complete: '#',
     remaining: '⠂',


### PR DESCRIPTION
The current characters are left and right double parenthesis, however it seems that these characters are not available in very many fonts. This means users leveraging a terminal that doesn't support fallback fonts for missing glyphs will get the unicode missing character glyph instead.

To make this a little cleaner, I swapped them out for standard single left and right parenthesis which should be available in the vast majority of fonts.
