### PR TITLE
fix: move demo.js to the docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ setTimeout(() => { gauge.pulse(); gauge.show("working…", 0.99) }, 2000)
 setTimeout(() => gauge.hide(), 2300)
 ```
 
-See also the [demos](demo.js):
+See also the [demos](docs/demo.js):
 
 ![](./docs/gauge-demo.gif)
 

--- a/docs/demo.js
+++ b/docs/demo.js
@@ -1,5 +1,5 @@
-var Gauge = require('./')
-var gaugeDefault = require('./themes.js')
+var Gauge = require('..')
+var gaugeDefault = require('../lib/themes.js')
 var onExit = require('signal-exit')
 
 var activeGauge


### PR DESCRIPTION
`npm run lint` will complain, though, so alternatively the file could be moved to a new folder or the docs folder.

Note that currently the file is linked in README.md from the root folder.